### PR TITLE
feat: Enhance credentials script to support AWS secret versioning

### DIFF
--- a/credentials.sh
+++ b/credentials.sh
@@ -1,9 +1,18 @@
 #!/bin/sh
 if [ -n "$AWS_SECRET_ID" ]
 then
-    aws secretsmanager get-secret-value --secret-id ${AWS_SECRET_ID} --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' | sed 's/[\&"'\''()$<>|;`]/\\&/g' > /tmp/secrets.env
+    #
+    CMD="aws secretsmanager get-secret-value --secret-id ${AWS_SECRET_ID}"
+
+    #
+    if [ -n "$AWS_SECRET_VERSION" ]
+    then
+        CMD="$CMD --version-stage ${AWS_SECRET_VERSION}"
+    fi
+
+    #
+    $CMD --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' | sed 's/[\&"'\''()$<>|;`]/\\&/g' > /tmp/secrets.env
     eval $(cat /tmp/secrets.env | sed 's/^/export /')
     rm -f /tmp/secrets.env
 fi
-
 sql-migrate $@


### PR DESCRIPTION
This pull request includes a change to the `credentials.sh` script to enhance the handling of AWS secret versions. The most important change is the addition of conditional logic to include the AWS secret version stage if it is specified.

Enhancements to AWS secret handling:

* [`credentials.sh`](diffhunk://#diff-3fb7d94f59cb740bfac43dda6e40c7092a2091819e03b73ef9624781ee971afeL4-L8): Added conditional logic to include the AWS secret version stage in the `aws secretsmanager get-secret-value` command if the `AWS_SECRET_VERSION` environment variable is set.